### PR TITLE
Support templated harbor fee effects

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -11,11 +11,11 @@
       "options": {
         "1": {
           "text": "Pay the standard fee ({harbor_fee} gold) and request berthing.",
-          "effect": { "gold": -8, "morale": 2 }
+          "effect": { "gold": "-{harbor_fee}", "morale": 2 }
         },
         "2": {
           "text": "Offer a small gift of spices to soften the fee.",
-          "effect": { "gold": -4, "spices": -1, "morale": 1 }
+          "effect": { "gold": "-{harbor_fee_minus_4}", "spices": -1, "morale": 1 }
         },
         "3": {
           "text": "Refuse and return to anchorage to think.",
@@ -28,7 +28,7 @@
           "options": {
             "2": {
               "text": "Hint at martial protection for reduced fees.",
-              "effect": { "gold": -3, "morale": 2 }
+              "effect": { "gold": "-{harbor_fee_minus_3}", "morale": 2 }
             }
           }
         },
@@ -37,7 +37,7 @@
           "options": {
             "2": {
               "text": "Invoke pious hospitality and offer a token gift.",
-              "effect": { "gold": -2, "spices": -1, "morale": 2 }
+              "effect": { "gold": "-{harbor_fee_minus_2}", "spices": -1, "morale": 2 }
             }
           }
         },
@@ -46,7 +46,7 @@
           "options": {
             "2": {
               "text": "Present neat manifests to negotiate a merchant’s rate.",
-              "effect": { "gold": -3, "morale": 1 }
+              "effect": { "gold": "-{harbor_fee_minus_3}", "morale": 1 }
             }
           }
         }

--- a/straits_project.py
+++ b/straits_project.py
@@ -333,6 +333,15 @@ class EventEngine:
         for key, opt in list(opts.items()):
             if "text" in opt and isinstance(opt["text"], str):
                 opt["text"] = self._format_text(opt["text"], ctx)
+            effect = opt.get("effect")
+            if isinstance(effect, dict):
+                new_effect: Dict[str, Any] = {}
+                for eff_key, eff_val in effect.items():
+                    if isinstance(eff_val, str):
+                        new_effect[eff_key] = self._format_text(eff_val, ctx)
+                    else:
+                        new_effect[eff_key] = eff_val
+                opt["effect"] = new_effect
         return out
 
     def _resolve_event(self, event: Dict[str, Any], state: GameState, once_key: Optional[str] = None):
@@ -354,8 +363,22 @@ class EventEngine:
         if choice not in options:
             print("You hesitate, and time slips by...")
         else:
-            effect = options[choice].get("effect", {})
-            state.apply_effect(effect)
+            raw_effect = options[choice].get("effect", {})
+            effect_clean: Dict[str, Any] = {}
+            if isinstance(raw_effect, dict):
+                for stat, delta in raw_effect.items():
+                    if isinstance(delta, str):
+                        delta_str = delta.strip()
+                        try:
+                            effect_clean[stat] = int(delta_str)
+                        except ValueError:
+                            try:
+                                effect_clean[stat] = int(float(delta_str))
+                            except ValueError:
+                                effect_clean[stat] = 0
+                    else:
+                        effect_clean[stat] = delta
+            state.apply_effect(effect_clean)
             print("\nOutcome applied.")
         if once_key:
             state.once_flags.append(once_key)
@@ -368,6 +391,10 @@ class EventEngine:
             "harbormaster_name": hm["name"] if hm else "the harbormaster",
             "harbor_fee": hm["fees"] if hm else 8
         }
+        fee = ctx["harbor_fee"]
+        if isinstance(fee, (int, float)):
+            for discount in range(1, 6):
+                ctx[f"harbor_fee_minus_{discount}"] = max(int(fee) - discount, 0)
         return ctx
 
     def trigger_random(self, pool_name: str, state: GameState):


### PR DESCRIPTION
## Summary
- allow event option effects to use templated values and coerce formatted numbers before applying them
- extend the harbor fee context with discounted variants for negotiation options
- update the harbormaster_intro event to charge each port’s listed fee via templated effects

## Testing
- python -m compileall straits_project.py
- python - <<'PY'
from straits_project import EventEngine, GameState, load_events, load_world, DATA_DIR, EVENTS_PATH, WORLD_PATH

world = load_world(WORLD_PATH)
events = load_events(EVENTS_PATH)
engine = EventEngine(events)

for port in ["Aceh", "Ternate"]:
    state = GameState("Portuguese Conquistador", world)
    state.current_location = port
    state.current_location_type = "major_port"
    ctx = engine._context_for_event(state)
    base_event = events["special_events"][0]
    ev = engine._merge_role_variant(base_event, state.role)
    ev_fmt = engine._apply_templating(ev, ctx)
    raw_effect = ev_fmt["options"]["1"]["effect"]
    effect_clean = {}
    for k, v in raw_effect.items():
        if isinstance(v, str):
            v = v.strip()
            try:
                effect_clean[k] = int(v)
            except ValueError:
                effect_clean[k] = 0
        else:
            effect_clean[k] = v
    before = state.gold
    state.apply_effect(effect_clean)
    after = state.gold
    print(port, ctx["harbor_fee"], effect_clean, before, after)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d0d4e92f008330855eb1b6b0792013